### PR TITLE
Task/td 20

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation 'org.springframework:spring-test'
 }
 
 dependencyManagement {

--- a/src/main/java/com/yeoro/twogether/domain/member/service/EmailVerificationService.java
+++ b/src/main/java/com/yeoro/twogether/domain/member/service/EmailVerificationService.java
@@ -48,4 +48,18 @@ public class EmailVerificationService {
     public void clearVerificationInfo(String email) {
         redisTemplate.delete(PREFIX + email);
     }
+
+    // 테스트용 데이터 추가를 위한 메서드: 이메일 인증을 건너뛰고 강제로 "인증 완료" 상태
+    public void markVerifiedForInit(String email) {
+        String key = PREFIX + email;
+        redisTemplate.opsForHash().put(key, "isVerified", true);
+
+        // code 필드가 비어 있으면 dummy 값 넣어줌
+        if (redisTemplate.opsForHash().get(key, "code") == null) {
+            redisTemplate.opsForHash().put(key, "code", "INIT");
+        }
+
+        redisTemplate.expire(key, TTL);
+    }
+
 }

--- a/src/main/java/com/yeoro/twogether/domain/member/service/Impl/MemberServiceImpl.java
+++ b/src/main/java/com/yeoro/twogether/domain/member/service/Impl/MemberServiceImpl.java
@@ -47,6 +47,7 @@ public class MemberServiceImpl implements MemberService {
      * 일반 회원가입
      */
     @Override
+    @Transactional
     public LoginResponse signup(SignupRequest request, HttpServletResponse response) {
         if (memberRepository.existsByEmail(request.email())) {
             throw new ServiceException(ErrorCode.EMAIL_ALREADY_EXISTS);

--- a/src/main/java/com/yeoro/twogether/global/init/InitTestUsersRunner.java
+++ b/src/main/java/com/yeoro/twogether/global/init/InitTestUsersRunner.java
@@ -1,0 +1,114 @@
+package com.yeoro.twogether.global.init;
+
+import com.yeoro.twogether.domain.member.dto.request.LoginRequest;
+import com.yeoro.twogether.domain.member.dto.request.SignupRequest;
+import com.yeoro.twogether.domain.member.dto.response.LoginResponse;
+import com.yeoro.twogether.domain.member.entity.Gender;
+import com.yeoro.twogether.domain.member.entity.Member;
+import com.yeoro.twogether.domain.member.repository.MemberRepository;
+import com.yeoro.twogether.domain.member.service.EmailVerificationService;
+import com.yeoro.twogether.domain.member.service.MemberService;
+import com.yeoro.twogether.global.constant.AppConstants;
+import jakarta.servlet.http.Cookie;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+@ConditionalOnProperty(name = "app.init.test-users", havingValue = "true", matchIfMissing = false)
+@RequiredArgsConstructor
+public class InitTestUsersRunner implements ApplicationRunner {
+
+    private final MemberService memberService;
+    private final MemberRepository memberRepository;
+    private final EmailVerificationService emailVerificationService;
+
+    @Override
+    @Transactional
+    public void run(ApplicationArguments args) {
+
+        TestUser u1 = new TestUser("testUser1", "testUser1@example.com", "Aa123456!");
+        TestUser u2 = new TestUser("testUser2", "testUser2@example.com", "Bb123456!");
+
+        TokenBundle t1 = ensureUserAndIssueTokens(u1);
+        TokenBundle t2 = ensureUserAndIssueTokens(u2);
+
+        printTopBanner(t1, t2);
+    }
+
+    private TokenBundle ensureUserAndIssueTokens(TestUser u) {
+        // 1) 이메일 인증 완료 상태로 강제 세팅
+        emailVerificationService.markVerifiedForInit(u.email());
+
+        // 2) 계정 없으면 회원가입
+        Member member = memberRepository.findByEmail(u.email()).orElse(null);
+        if (member == null) {
+            MockHttpServletResponse signupResp = new MockHttpServletResponse();
+            SignupRequest req = new SignupRequest(
+                    u.email(),
+                    u.password(),
+                    u.nickname(),
+                    null,
+                    null,
+                    Gender.UNKNOWN,
+                    null
+            );
+            memberService.signup(req, signupResp);
+            emailVerificationService.clearVerificationInfo(u.email()); // 남은 인증 데이터 정리
+        } else if (member.getPartner() != null) {
+            // 연인 연동 제거 보장
+            member.connectPartner(null);
+            memberRepository.save(member);
+        }
+
+        // 3) 로그인 해서 토큰 발급
+        MockHttpServletRequest loginReq = new MockHttpServletRequest();
+        MockHttpServletResponse loginResp = new MockHttpServletResponse();
+        LoginResponse login = memberService.login(new LoginRequest(u.email(), u.password()), loginReq, loginResp);
+
+        String access = login.accessToken();
+        String refresh = extractRefreshToken(loginResp);
+
+        return new TokenBundle(u.nickname(), u.email(), access, refresh);
+    }
+
+    private String extractRefreshToken(MockHttpServletResponse response) {
+        if (response.getCookies() != null) {
+            for (Cookie c : response.getCookies()) {
+                if (AppConstants.REFRESH_TOKEN.equals(c.getName())) {
+                    return c.getValue();
+                }
+            }
+        }
+        return "(refresh not found)";
+    }
+
+    private void printTopBanner(TokenBundle t1, TokenBundle t2) {
+        log.error("\n" +
+                        "================================= TEST USERS =================================\n" +
+                        " USER: {}  | EMAIL: {}\n" +
+                        "   ACCESS : {}\n" +
+                        "   REFRESH: {}\n" +
+                        "------------------------------------------------------------------------------\n" +
+                        " USER: {}  | EMAIL: {}\n" +
+                        "   ACCESS : {}\n" +
+                        "   REFRESH: {}\n" +
+                        "===============================================================================\n",
+                t1.nickname(), t1.email(), t1.accessToken(), t1.refreshToken(),
+                t2.nickname(), t2.email(), t2.accessToken(), t2.refreshToken()
+        );
+    }
+
+    private record TestUser(String nickname, String email, String password) {}
+    private record TokenBundle(String nickname, String email, String accessToken, String refreshToken) {}
+}


### PR DESCRIPTION
## 🔥 관련 이슈

- Jira 이슈: [TD-20](https://yeoro-dev.atlassian.net/browse/TD-20)
- Github: closed #22 
<br/>

## 📝 변경사항

- [x] 서버 실행시 테스트용 사용자 2명을 추가

<br/>

<img width="391" height="241" alt="image" src="https://github.com/user-attachments/assets/3b2c26fc-85eb-4f69-9d1b-b9df0700dd5d" />

<br/>

## 📋 체크리스트

- [x] Jira 이슈와 연결함
- [x] PR 내용과 커밋 메시지에 이슈 키 포함

<br/>

---


🙌 봐주세요! :
> 서버 시작시 토큰이 아래의 로그에 뜨게 됩니다. 해당 부분 참고하셔서 사용하면 좋을 것 같습니다.
연인 연동은 되어있지 않습니다. 연동 시에는 각자의 토큰이 별도로 재생성 됩니다.
연인 연동시 요청자는 새로 토큰이 바로 발급이 되는데 반해 연동 코드를 요구한 사용자는 바로 반영이 되지 않습니다.
해당 유저는 재 로그인을 할 수 있게 해주셔야 합니다.
된다면 둘 모두 바로 재 로그인 창으로 넘어가게 설정해두셔도 좋을 것 같아요!

[TD-20]: https://yeoro-dev.atlassian.net/browse/TD-20?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ